### PR TITLE
Make other Google profile fields available from the OAuth token

### DIFF
--- a/grails-app/services/grails/plugin/springsecurity/oauth2/google/GoogleOAuth2Service.groovy
+++ b/grails-app/services/grails/plugin/springsecurity/oauth2/google/GoogleOAuth2Service.groovy
@@ -52,7 +52,7 @@ class GoogleOAuth2Service extends OAuth2AbstractProviderService {
             log.error("No user email from " + getProviderID() + ". Response was:\n" + response.body)
             throw new OAuth2Exception("No user id from " + getProviderID())
         }
-        new GoogleOauth2SpringToken(accessToken, user?.email, providerID)
+        new GoogleOauth2SpringToken(accessToken, user, providerID)
     }
 
 }

--- a/src/main/groovy/grails/plugin/springsecurity/oauth2/google/GoogleOauth2SpringToken.groovy
+++ b/src/main/groovy/grails/plugin/springsecurity/oauth2/google/GoogleOauth2SpringToken.groovy
@@ -15,11 +15,18 @@ import grails.plugin.springsecurity.oauth2.token.OAuth2SpringToken
 class GoogleOauth2SpringToken  extends OAuth2SpringToken{
 
     private String email
+    private String givenName
+    private String familyName
+    private URL pictureURL
     private String providerId
 
-    GoogleOauth2SpringToken(OAuth2AccessToken accessToken, String email, String providerId) {
+    GoogleOauth2SpringToken(OAuth2AccessToken accessToken, Map props, String providerId) {
         super(accessToken)
-        this.email = email
+        this.email = props.email
+        this.givenName = props.given_name
+        this.familyName = props.family_name
+        if (props.picture)
+            this.pictureURL = new URL(props.picture)
         this.providerId = providerId
     }
 
@@ -36,5 +43,17 @@ class GoogleOauth2SpringToken  extends OAuth2SpringToken{
     @Override
     String getScreenName() {
         return email
+    }
+
+    String getGivenName() {
+        return givenName
+    }
+
+    String getFamilyName() {
+        return familyName
+    }
+
+    URL getPictureURL() {
+        return pictureURL
     }
 }


### PR DESCRIPTION
The user's full name and profile picture are returned by Google OAuth for the profile scope. I added these in to the token so that they're available. This is a slightly better version of my modification for the Grails 2 plugin:
https://github.com/donbeave/grails-spring-security-oauth-google/commit/33585b363addb42d2f165653fa0c403cdea9a3db